### PR TITLE
Set 'contents: read' permissions for GitHub Actions workflows

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - name: pull-request
-        uses: diillson/auto-pull-request@v1.0.1
+        uses: diillson/auto-pull-request@4cf50b3681cd76250f37841466e61e514a377064 # v1.0.1
         with:
           destination_branch: 'main'
           github_token: ${{ secrets.SEMVER_TOKEN }}

--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   pull_request:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - name: pull-request

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,8 @@ jobs:
       contents: read
   security:
     uses: ./.github/workflows/security.yml
-    permissions: {}
+    permissions:
+      contents: read
   test:
     uses: ./.github/workflows/test.yml
     permissions: {}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,6 +19,8 @@ jobs:
   
   sast:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - name: semgrep-action
@@ -26,6 +28,8 @@ jobs:
 
   secrets:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     container:
       image: ghcr.io/gitleaks/gitleaks:latest
     steps:


### PR DESCRIPTION
Added 'contents: read' permissions to SAST and secrets jobs in the security workflow file. This change ensures the workflows have appropriate and minimal permissions needed to execute reliably and securely.

## Summary by Sourcery

CI:
- Set the `contents: read` permission for the SAST and secrets jobs in the security workflow. This ensures the workflows have only the necessary permissions to access the repository contents and improves security by following the principle of least privilege.