### PR TITLE
Update action versions and refine workflow permissions

### DIFF
--- a/.github/workflows/merge-checks.yml
+++ b/.github/workflows/merge-checks.yml
@@ -17,12 +17,16 @@ on:
 jobs:
   sast:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - name: semgrep-action
-        uses: semgrep/semgrep-action@v1
+        uses: semgrep/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d #v1
   secrets:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     container:
       image: ghcr.io/gitleaks/gitleaks:latest
     steps:

--- a/.github/workflows/package-and-publish.yml
+++ b/.github/workflows/package-and-publish.yml
@@ -35,7 +35,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish container image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
         env:
           VERSION: ${{ inputs.version }}
           IMAGE_NAME: black-hole

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
 
-      - uses: denoland/setup-deno@v2
+      - uses: denoland/setup-deno@27e0043effb637fb8409496e05bd8472e4b87554 # v2
         with:
           deno-version: v2.x
       - run: deno lint
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - name: semgrep-action
-        uses: semgrep/semgrep-action@v1
+        uses: semgrep/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d #v1
 
   secrets:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Updated specific actions in multiple workflows to use commit-sha references for improved reliability and security. Added read-only permissions to steps in `merge-checks.yml` for better security practices. These changes ensure consistency and enhance security across workflows.

## Summary by Sourcery

Pin GitHub actions versions to their commit SHAs and restrict permissions for the merge checks workflow to read-only.

CI:
- Updated GitHub Actions workflows to pin actions to commit SHAs for increased security and reliability.
- Restrict workflow permissions to read-only access for enhanced security in the merge checks workflow