### PR TITLE
Update GitHub Actions token for auto PR workflow

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -17,4 +17,4 @@ jobs:
         uses: diillson/auto-pull-request@4cf50b3681cd76250f37841466e61e514a377064 # v1.0.1
         with:
           destination_branch: 'main'
-          github_token: ${{ secrets.SEMVER_TOKEN }}
+          github_token: ${{ secrets.SEMVER_TOKEN_NO_EXPIRATION }}


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Adjust auto pull request GitHub Actions workflow to stop using the SEMVER_TOKEN secret for authentication.